### PR TITLE
修复回复消息时回复内容在“@”前会丢失的问题

### DIFF
--- a/assets/default-theme/app.js
+++ b/assets/default-theme/app.js
@@ -419,7 +419,7 @@ function parseMessage(message) {
                 break;
             case "reply":
                 if (message[1]?.type === "at" && message[3]?.type === "at" && message[1]?.data.qq === message[3]?.data.qq) {
-                    message.splice(1, 2);
+                    message.splice(1, 1);
                 }
                 msg += `<a href="#${v.data.id}" onclick="document.querySelector('#${filterMsgIdSelector(v.data.id).replace(/\\/g, "\\\\")}')?.nextElementSibling.animate([{'background':'var(--vscode-sideBar-background)'}],{duration: 3000})">[回复]</a>`;
                 break;


### PR DESCRIPTION
回复消息的message结构为
[Reply,At,Text,At,Text]
其中前两个为回复消息的固定数据
后三个分别为 “@前的消息” “所要@的人(可删除）” “@后的消息”
在对message的去重中 只要去掉前一个At即可，不应该去掉第一个Text
修改前：
![image](https://user-images.githubusercontent.com/13182410/159646752-20d1f2d7-743c-4501-8e50-7ec3eead7911.png)

修改后：
![image](https://user-images.githubusercontent.com/13182410/159646474-2b1540a7-d323-484f-9252-501315b0b724.png)
