### PR TITLE
支持聊天气泡内直接显示图片

### DIFF
--- a/assets/default-theme/style.css
+++ b/assets/default-theme/style.css
@@ -64,10 +64,6 @@
     min-width:9px;
     min-height:18px
 }
-.lite-chatbox .content img{
-    width:100%;
-    height:auto
-}
 .lite-chatbox .content a{
     color:var(--vscode-editorLink-activeForeground);
     margin:0 2px;
@@ -168,7 +164,6 @@ body {
     background-color: var(--vscode-focusBorder);
 }
 .lite-chatbox .content img {
-    width: auto;
     vertical-align: bottom;
 }
 .lite-chatbox .content img.face {

--- a/assets/preload.js
+++ b/assets/preload.js
@@ -31,6 +31,7 @@
     vsc.assets_path = env.attributes.path?.value + "/";
     vsc.faces_path = vsc.assets_path + "faces/";
     vsc.t = Number(env.attributes.t?.value);
+    vsc.showImage = (env.attributes.showImage?.value === "true");
 
     /**
      * @param {import("oicq").CommonEventData} data 

--- a/assets/types.d.ts
+++ b/assets/types.d.ts
@@ -13,6 +13,7 @@ export interface Webview extends EventTarget {
     readonly assets_path: string; //assets文件夹路径("/"结尾)
     readonly faces_path: string; //表情文件夹路径("/"结尾)
     readonly t: number; //vsc启动时间戳，用于解决头像缓存问题
+    readonly showImage: boolean; //是否在气泡中直接显示图片
     readonly TimeoutError: typeof Error;
 
     // 监听新消息事件

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "vscode-qq",
-			"version": "1.4.1",
+			"version": "1.4.2",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"get-port": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,21 @@
 	],
 	"main": "./out/extension.js",
 	"contributes": {
+		"configuration": {
+			"title": "VSCode QQ",
+			"properties": {
+				"vscode-qq.showImage": {
+					"type": "string",
+					"default": "false",
+					"enum": ["true", "false"],
+					"enumDescriptions": [
+						"在聊天气泡中显示图片",
+						"不在聊天气泡中显示图片（可以鼠标悬停预览图片）"
+					],
+					"description": "修改聊天页面的图片显示方案"
+				}
+			}
+		},
 		"commands": [
 			{
 				"command": "oicq.contact.pin",

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -47,6 +47,8 @@ function getHtml(id: string, webview: vscode.Webview) {
     }
     const { self, type, uin } = parseContactId(id);
     const path = webview.asWebviewUri(vscode.Uri.joinPath(ctx.extensionUri, "assets")).toString();
+    const vscodeQQConfig = vscode.workspace.getConfiguration("vscode-qq");
+    const showImage = vscodeQQConfig.get<string>("showImage");
     return `<!DOCTYPE html>
 <html>
 <head>
@@ -56,7 +58,7 @@ function getHtml(id: string, webview: vscode.Webview) {
     <link rel="stylesheet" type="text/css" href="${css}" />
 </head>
 <body>
-    <env self_id="${self}" nickname="${client.nickname}" c2c="${type === "u" ? 1 : 0}" target_id="${uin}" temp="0" path="${path}" t="${T}">
+    <env self_id="${self}" nickname="${client.nickname}" c2c="${type === "u" ? 1 : 0}" target_id="${uin}" temp="0" path="${path}" t="${T}" showImage="${showImage}">
     <script src="${preload}"></script>
     <script src="${js}"></script>
 </body>


### PR DESCRIPTION
修改了default主题，从而支持聊天气泡内直接显示预览图，双击图片可以放大，再次双击可以变回预览图。这个对自己发出的“粘贴的图片”同样有效。用户可以选择是否启用这个功能，启用后会屏蔽掉原有的“链接+鼠标悬停小窗预览”模式。开关默认是false（禁用）。

实际效果如下，个人感觉体验不错：

![image](https://user-images.githubusercontent.com/46660947/160262971-f604f7bf-7f23-4f4c-9390-7ae14a9b2a1d.png)

![Screenshot](https://user-images.githubusercontent.com/46660947/160263144-febce427-5faa-4b5d-b90c-d6d3822a0b73.png)

